### PR TITLE
Switch from jsonbox.io to jsconnect.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ Implementing a Simple URL Shortner which can be used without need of any hardcor
 * Database : [jsonconnect.com](https://jsonconnect.com/)
 (Previously , jsonstore was used but several downtimes forced me to switch to jsonbox.io, then to jsconnect as jsonbox went offline)
 
+Jsconnect.com [is a fork of Jsonbox.io](https://github.com/bauripalash/fossurl/issues/29) - learn more on [the project's homepage](https://github.com/jsonconnect/jsonconnect).
+
 **Please note that your shortened links will be valid for only 30 days, due to [Jsconnect.com limitations](https://jsonconnect.com/)**.
 
 ### 🛠️ Features
@@ -45,12 +47,14 @@ Implementing a Simple URL Shortner which can be used without need of any hardcor
 * **Thanks to**
 * [The Noun Project for the dragonfly icon on homepage](https://thenounproject.com/search/?q=dragonfly&i=2415046)
 * [The Noun Project for the dragonfly icon on README](https://thenounproject.com/search/?q=dragonfly&i=1451640) [(Both are Licensed under CC BY 3.0 US)](https://creativecommons.org/licenses/by/3.0/us/)
+* [Anthony Arutyunov](https://github.com/AnthonyArutyunov) for hosting Jsconnect.com
 
 ---
 * **⚠ Warning :**
+
 Please Don't Use FossUrl to shorten any sensitive Information , important files or any other sensitive things which can create privacy issues for an individual or a company or an organisation.
 
-**Keep in mind that your shortened links will be valid for only 30 days, due to [Jsconnect.com limitations](https://jsonconnect.com/)**.
+Keep in mind that your shortened links will be valid for only 30 days, due to [Jsconnect.com limitations](https://jsonconnect.com/).
 
 * **Sponsor :** 
 [![BrowserStack](./static/browserstack.svg)](https://browserstack.com)

--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@ Implementing a Simple URL Shortner which can be used without need of any hardcor
 
 Jsconnect.com [is a fork of Jsonbox.io](https://github.com/bauripalash/fossurl/issues/29) - learn more on [the project's homepage](https://github.com/jsonconnect/jsonconnect).
 
-**Please note that your shortened links will be valid for only 30 days, due to [Jsconnect.com limitations](https://jsonconnect.com/)**.
 
 ### 🛠️ Features
 * It's fast
@@ -54,7 +53,6 @@ Jsconnect.com [is a fork of Jsonbox.io](https://github.com/bauripalash/fossurl/i
 **⚠ Warning :**
 
 * Please Don't Use FossUrl to shorten any sensitive Information , important files or any other sensitive things which can create privacy issues for an individual or a company or an organisation.
-* Keep in mind that your shortened links will be valid for only 30 days, due to [Jsconnect.com limitations](https://jsonconnect.com/).
 
 * **Sponsor :** 
 [![BrowserStack](./static/browserstack.svg)](https://browserstack.com)

--- a/README.md
+++ b/README.md
@@ -29,6 +29,11 @@ Jsconnect.com [is a fork of Jsonbox.io](https://github.com/bauripalash/fossurl/i
 * It doesn't require any hosting server
 * You can use it just by forking the repo and running a script
 
+### Where is my data stored?
+
+The connection between your shorten URL and the long one is stored by jsonconnect.com, and will be available as long as the server is alive. 
+
+The server is set to [keep the data for 99999 days](https://github.com/jsonconnect/jsonconnect/issues/2#issuecomment-825011113), which is somewhere over 200 years 😎!
 
 ## 👻 Wanna Help Improve It?
 #### Steps:

--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ Implementing a Simple URL Shortner which can be used without need of any hardcor
 * CSS
 * JavaScript
 * Database : [jsonconnect.com](https://jsonconnect.com/)
-(Previously , jsonstore was used but several downtimes forced me to switch to jsonbox.io, then to jsconnect as jsonbox went offline)
+(Previously , jsonstore was used but several downtimes forced me to switch to jsonbox.io, then to jsonconnect as jsonbox went offline)
 
-Jsconnect.com [is a fork of Jsonbox.io](https://github.com/bauripalash/fossurl/issues/29) - learn more on [the project's homepage](https://github.com/jsonconnect/jsonconnect).
+Jsonconnect.com [is a fork of Jsonbox.io](https://github.com/bauripalash/fossurl/issues/29) - learn more on [the project's homepage](https://github.com/jsonconnect/jsonconnect).
 
 
 ### 🛠️ Features
@@ -52,7 +52,7 @@ The server is set to [keep the data for 99999 days](https://github.com/jsonconne
 
 * [The Noun Project for the dragonfly icon on homepage](https://thenounproject.com/search/?q=dragonfly&i=2415046)
 * [The Noun Project for the dragonfly icon on README](https://thenounproject.com/search/?q=dragonfly&i=1451640) [(Both are Licensed under CC BY 3.0 US)](https://creativecommons.org/licenses/by/3.0/us/)
-* [Anthony Arutyunov](https://github.com/AnthonyArutyunov) for hosting Jsconnect.com
+* [Anthony Arutyunov](https://github.com/AnthonyArutyunov) for hosting Jsonconnect.com
 
 ---
 **⚠ Warning :**

--- a/README.md
+++ b/README.md
@@ -18,8 +18,10 @@ Implementing a Simple URL Shortner which can be used without need of any hardcor
 * HTML
 * CSS
 * JavaScript
-* Database : [jsonbox.io](https://jsonbox.io)
-(Previously , jsonstore was used but several downtimes forced me to switch to jsonbox)
+* Database : [jsonconnect.com](https://jsonconnect.com/)
+(Previously , jsonstore was used but several downtimes forced me to switch to jsonbox.io, then to jsconnect as jsonbox went offline)
+
+**Please note that your shortened links will be valid for only 30 days, due to [Jsconnect.com limitations](https://jsonconnect.com/)**.
 
 ### 🛠️ Features
 * It's fast
@@ -48,6 +50,7 @@ Implementing a Simple URL Shortner which can be used without need of any hardcor
 * **⚠ Warning :**
 Please Don't Use FossUrl to shorten any sensitive Information , important files or any other sensitive things which can create privacy issues for an individual or a company or an organisation.
 
+**Keep in mind that your shortened links will be valid for only 30 days, due to [Jsconnect.com limitations](https://jsonconnect.com/)**.
 
 * **Sponsor :** 
 [![BrowserStack](./static/browserstack.svg)](https://browserstack.com)

--- a/README.md
+++ b/README.md
@@ -44,17 +44,17 @@ Jsconnect.com [is a fork of Jsonbox.io](https://github.com/bauripalash/fossurl/i
 * Create Issues to submit improvement ideas
 
 ---
-* **Thanks to**
+**Thanks to**
+
 * [The Noun Project for the dragonfly icon on homepage](https://thenounproject.com/search/?q=dragonfly&i=2415046)
 * [The Noun Project for the dragonfly icon on README](https://thenounproject.com/search/?q=dragonfly&i=1451640) [(Both are Licensed under CC BY 3.0 US)](https://creativecommons.org/licenses/by/3.0/us/)
 * [Anthony Arutyunov](https://github.com/AnthonyArutyunov) for hosting Jsconnect.com
 
 ---
-* **⚠ Warning :**
+**⚠ Warning :**
 
-Please Don't Use FossUrl to shorten any sensitive Information , important files or any other sensitive things which can create privacy issues for an individual or a company or an organisation.
-
-Keep in mind that your shortened links will be valid for only 30 days, due to [Jsconnect.com limitations](https://jsonconnect.com/).
+* Please Don't Use FossUrl to shorten any sensitive Information , important files or any other sensitive things which can create privacy issues for an individual or a company or an organisation.
+* Keep in mind that your shortened links will be valid for only 30 days, due to [Jsconnect.com limitations](https://jsonconnect.com/).
 
 * **Sponsor :** 
 [![BrowserStack](./static/browserstack.svg)](https://browserstack.com)

--- a/src/head.js
+++ b/src/head.js
@@ -1,4 +1,4 @@
-var endpoint = "https://jsonbox.io/box_f4a3d05ef8fe374ac8ea";
+var endpoint = "https://jsonconnect.com/connect_21ad6e588abb4198e45b";
 
 function fetchJSON(a) {
     var f = new XMLHttpRequest;

--- a/src/runme.py
+++ b/src/runme.py
@@ -1,7 +1,7 @@
 import re
 import uuid
 
-JSONBOX_WEBSITE = "https://jsonbox.io/"
+JSONBOX_WEBSITE = "https://jsonconnect.com/"
 
 endpoint_source = '''var endpoint="%s";function fetchJSON(a){var f=new XMLHttpRequest;f.open("GET",a,false);f.send(null);return f.responseText}function isURL(a){var f=/^(?:(?:https?|ftp):\/\/)?(?:(?!(?:10|127)(?:\.\d{1,3}){3})(?!(?:169\.254|192\.168)(?:\.\d{1,3}){2})(?!172\.(?:1[6-9]|2\d|3[0-1])(?:\.\d{1,3}){2})(?:[1-9]\d?|1\d\d|2[01]\d|22[0-3])(?:\.(?:1?\d{1,2}|2[0-4]\d|25[0-5])){2}(?:\.(?:[1-9]\d?|1\d\d|2[0-4]\d|25[0-4]))|(?:(?:[a-z\u00a1-\uffff0-9]-*)*[a-z\u00a1-\uffff0-9]+)(?:\.(?:[a-z\u00a1-\uffff0-9]-*)*[a-z\u00a1-\uffff0-9]+)*(?:\.(?:[a-z\u00a1-\uffff]{2,})))(?::\d{2,5})?(?:\/\S*)?$/;if(f.test(a)){console.log(f.test(a));return true}else{console.log(f.test(a));return false}}var hashh=window.location.hash.substr(1);if(window.location.hash!=""){var res=JSON.parse(fetchJSON(endpoint+"/?q=s:"+hashh))[0];var data=res["l"];if(data!=null){if(isURL(data)){window.location.href=data}}}
 '''

--- a/src/runme.py
+++ b/src/runme.py
@@ -1,7 +1,7 @@
 import re
 import uuid
 
-JSONBOX_WEBSITE = "https://jsonconnect.com/"
+JSONHOST_WEBSITE = "https://jsonconnect.com/"
 
 endpoint_source = '''var endpoint="%s";function fetchJSON(a){var f=new XMLHttpRequest;f.open("GET",a,false);f.send(null);return f.responseText}function isURL(a){var f=/^(?:(?:https?|ftp):\/\/)?(?:(?!(?:10|127)(?:\.\d{1,3}){3})(?!(?:169\.254|192\.168)(?:\.\d{1,3}){2})(?!172\.(?:1[6-9]|2\d|3[0-1])(?:\.\d{1,3}){2})(?:[1-9]\d?|1\d\d|2[01]\d|22[0-3])(?:\.(?:1?\d{1,2}|2[0-4]\d|25[0-5])){2}(?:\.(?:[1-9]\d?|1\d\d|2[0-4]\d|25[0-4]))|(?:(?:[a-z\u00a1-\uffff0-9]-*)*[a-z\u00a1-\uffff0-9]+)(?:\.(?:[a-z\u00a1-\uffff0-9]-*)*[a-z\u00a1-\uffff0-9]+)*(?:\.(?:[a-z\u00a1-\uffff]{2,})))(?::\d{2,5})?(?:\/\S*)?$/;if(f.test(a)){console.log(f.test(a));return true}else{console.log(f.test(a));return false}}var hashh=window.location.hash.substr(1);if(window.location.hash!=""){var res=JSON.parse(fetchJSON(endpoint+"/?q=s:"+hashh))[0];var data=res["l"];if(data!=null){if(isURL(data)){window.location.href=data}}}
 '''
@@ -16,14 +16,14 @@ def getEndpoint():
 def main():
     print("=== Welcome to FOSSURL Configuration Wizard! ===")
     endpoint = getEndpoint()
-    print("Your JSONBOX Endpoint is : " + JSONBOX_WEBSITE +  endpoint);
-    print("Your JSONBOX Dashboard URL is : " + JSONBOX_WEBSITE + "dashboard.html?box=" + endpoint )
+    print("Your JSONHOST Endpoint is : " + JSONHOST_WEBSITE +  endpoint);
+    print("Your JSONHOST Dashboard URL is : " + JSONHOST_WEBSITE + "dashboard.html?box=" + endpoint )
 
     with open("head.js" , "w") as f:
-        f.write(endpoint_source %(JSONBOX_WEBSITE +  endpoint))
+        f.write(endpoint_source %(JSONHOST_WEBSITE +  endpoint))
 
     with open("DELETE_ME.yml" , "w") as f:
-        f.write(info_yml %(JSONBOX_WEBSITE +  endpoint ,JSONBOX_WEBSITE + "dashboard.html?box=" + endpoint ))
+        f.write(info_yml %(JSONHOST_WEBSITE +  endpoint ,JSONHOST_WEBSITE + "dashboard.html?box=" + endpoint ))
 
 main()
 


### PR DESCRIPTION
The third-party service hosting the JSON data, [Jsonbox.io](https://jsonbox.io/), is scheduled to shut down on May 31, 2021.

This branch replaces Jsonbox.io with [Jsonconnect.com](https://jsonconnect.com/) , a [fork of Jsonbox](https://github.com/bauripalash/fossurl/issues/29).

This implementation was successfully tested by hosting the `/src` folder on a server powered by Gitlab pages. The Python script `runme.py` was also updated but not tested so far.

References:
- https://github.com/bauripalash/fossurl/issues/29
- https://github.com/bauripalash/fossurl/issues/28